### PR TITLE
Version 7.1.2.post1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ravendb==7.1.2
+ravendb~=7.1.2
 cryptography~=42.0.0

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"ravendb_embedded": "ravendb_embedded"},
     include_package_data=True,
     long_description=open("README.rst").read(),
-    version="7.1.2",
+    version="7.1.2.post1",
     description="RavenDB Embedded library to run RavenDB in an embedded way",
     author="RavenDB",
     author_email="support@ravendb.net",
@@ -53,7 +53,7 @@ setup(
     license="Custom EULA",
     keywords="ravendb embedded database nosql doc db",
     install_requires=[
-        "ravendb==7.1.2",
+        "ravendb~=7.1.2",
         "cryptography~=42.0.0",
     ],
     license_files="LICENSE",


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-953

```
WARNING: The candidate selected for download or install is a yanked version: 'ravendb' candidate (version 7.1.2 at https://files.pythonhosted.org/packages/8b/d3/16e2d3db1d96b6c15d181881085a54fc2a79bb9afeff2147420bab562cea/ravendb-7.1.2-py3-none-any.whl (from https://pypi.org/simple/ravendb/) (requires-python:~=3.9))
Reason for being yanked: This release is corrupted - it lacks Ai Agents `operations` library, which is exposed at the top-level of the library -> `import ravendb` causes error
```