### PR TITLE
Release 7.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ravendb~=7.2.2
+ravendb~=7.2.3
 cryptography>=42.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import urllib.request
 from setuptools.command.sdist import sdist
 
-RAVENDB_VERSION = "7.2.2"
+RAVENDB_VERSION = "7.2.3"
 ZIP_FILE_NAME = "server.zip"
 RAVENDB_DOWNLOAD_URL = f"https://www.nuget.org/api/v2/package/RavenDB.Embedded/{RAVENDB_VERSION}"
 
@@ -45,7 +45,7 @@ setup(
     package_dir={"ravendb_embedded": "ravendb_embedded"},
     include_package_data=True,
     long_description=open("README.rst").read(),
-    version="7.2.2",
+    version="7.2.3",
     description="RavenDB Embedded library to run RavenDB in an embedded way",
     author="RavenDB",
     author_email="support@ravendb.net",
@@ -53,7 +53,7 @@ setup(
     license="Custom EULA",
     keywords="ravendb embedded database nosql doc db",
     install_requires=[
-        "ravendb~=7.2.2",
+        "ravendb~=7.2.3",
         "cryptography>=42.0.0",
     ],
     license_files="LICENSE",


### PR DESCRIPTION
Release **ravendb-embedded 7.2.3** — aligns with the `ravendb` 7.2.3 client and bundles RavenDB Server 7.2.3.

Bumps `7.2.2 -> 7.2.3` in `setup.py` (`RAVENDB_VERSION` → bundles `RavenDB.Embedded` 7.2.3, `version`, `ravendb~=` pin) and `requirements.txt`. `cryptography>=42.0.0` unchanged.

Once merged, built and published to PyPI manually (twine).
