### PR TITLE
Add CI (tests + black, secured, .NET 8/10 matrix) for v7.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,59 @@
+name: tests
+
+on:
+  push:
+    branches: [v7.2]
+  pull_request:
+    branches: [v7.2]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    env:
+      # The server targets net8.0, so default resolution already exercises .NET 8. Runners
+      # preinstall .NET 8, so to actually exercise .NET 10 we force it via fx-version (empty
+      # = default resolution). See tests/pin_framework_version.
+      RAVENDB_TEST_FRAMEWORK_VERSION: "${{ matrix.fx }}"
+    strategy:
+      fail-fast: false
+      # Minimal spread: Python {3.9,3.13} x OS {ubuntu,windows} x .NET {8 default, 10 forced}
+      # each appears at least once.
+      matrix:
+        include:
+          - { os: ubuntu-latest, python: "3.13", dotnet: "10.0", fx: "10.0.x" }
+          - { os: ubuntu-latest, python: "3.9", dotnet: "8.0", fx: "" }
+          - { os: windows-latest, python: "3.13", dotnet: "10.0", fx: "10.0.x" }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Set up .NET ${{ matrix.dotnet }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Check formatting (black)
+        run: |
+          pip install black
+          black --check .
+
+      # Populates ravendb_embedded/target/nuget via the project's sdist hook (the server the
+      # tests copy from). setuptools is installed explicitly; modern virtualenvs omit it.
+      - name: Fetch bundled RavenDB server
+        run: |
+          pip install setuptools wheel
+          python setup.py sdist
+
+      - name: Run tests
+        run: python -m unittest discover -s tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,16 @@
+import os
+
+
 class Person:
     def __init__(self, Id: str = None, name: str = None):
         self.Id = Id
         self.name = name
+
+
+def pin_framework_version(server_options):
+    # CI's .NET-version matrix sets RAVENDB_TEST_FRAMEWORK_VERSION to force the server onto a
+    # specific runtime (e.g. "10.0.x"); a no-op locally when it's unset.
+    framework_version = os.environ.get("RAVENDB_TEST_FRAMEWORK_VERSION")
+    if framework_version:
+        server_options.framework_version = framework_version
+    return server_options

--- a/tests/certificates.py
+++ b/tests/certificates.py
@@ -1,0 +1,69 @@
+import datetime
+import ipaddress
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+
+def generate_self_signed_certificates(directory):
+    """Write server.pfx, client.pem and ca.crt into `directory`; return their paths.
+
+    The certificate carries the extensions RavenDB requires of a server certificate:
+    DigitalSignature key usage, serverAuth/clientAuth EKU, and SANs for how the embedded
+    server is reached (localhost + 127.0.0.1). The same cert doubles as the client cert,
+    which the server then trusts as a well-known admin certificate.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=3650))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("localhost"), x509.IPAddress(ipaddress.ip_address("127.0.0.1"))]),
+            critical=False,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                key_encipherment=True,
+                content_commitment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH, ExtendedKeyUsageOID.CLIENT_AUTH]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+
+    certificate_pem = certificate.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.TraditionalOpenSSL, serialization.NoEncryption()
+    )
+
+    server_pfx = Path(directory, "server.pfx")
+    client_pem = Path(directory, "client.pem")
+    ca_crt = Path(directory, "ca.crt")
+    server_pfx.write_bytes(
+        pkcs12.serialize_key_and_certificates(b"localhost", key, certificate, None, serialization.NoEncryption())
+    )
+    client_pem.write_bytes(key_pem + certificate_pem)
+    ca_crt.write_bytes(certificate_pem)
+    return str(server_pfx), str(client_pem), str(ca_crt)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest import TestCase
 
 from ravendb_embedded import EmbeddedServer, ServerOptions, CopyServerFromNugetProvider, DatabaseOptions
-from tests import Person
+from tests import Person, pin_framework_version
 
 
 class BasicTest(TestCase):
@@ -17,6 +17,7 @@ class BasicTest(TestCase):
                 server_options.logs_path = str(Path(temp_dir, "Logs"))
                 server_options.provider = CopyServerFromNugetProvider()
                 server_options.command_line_args = ["--Features.Availability=Experimental"]
+                pin_framework_version(server_options)
                 embedded.start_server(server_options)
 
                 database_options = DatabaseOptions.from_database_name("Test")
@@ -37,6 +38,7 @@ class BasicTest(TestCase):
                 server_options = ServerOptions()
                 server_options.data_directory = str(Path(temp_dir, "RavenDB"))
                 server_options.provider = CopyServerFromNugetProvider()
+                pin_framework_version(server_options)
                 embedded.start_server(server_options)
 
                 with embedded.get_document_store("Test") as store:

--- a/tests/test_custom_provider.py
+++ b/tests/test_custom_provider.py
@@ -1,3 +1,4 @@
+import shutil
 import tempfile
 from pathlib import Path
 from unittest import TestCase
@@ -5,7 +6,7 @@ from unittest import TestCase
 from ravendb_embedded.embedded_server import EmbeddedServer
 from ravendb_embedded.options import ServerOptions, DatabaseOptions
 from ravendb_embedded.provide import CopyServerFromNugetProvider
-from tests import Person
+from tests import Person, pin_framework_version
 
 
 class TestCustomProvider(TestCase):
@@ -15,14 +16,21 @@ class TestCustomProvider(TestCase):
         server_options.data_directory = str(Path(temp_dir, "RavenDB"))
         server_options.logs_path = str(Path(temp_dir, "Logs"))
         server_options.command_line_args = ["--Features.Availability=Experimental"]
+        pin_framework_version(server_options)
         return server_options
 
     def test_can_use_zip_as_external_server_source(self):
         with tempfile.TemporaryDirectory() as temp_dir:
+            # Zip the bundled server so the test does not depend on cwd or a pre-built archive.
+            server_zip = shutil.make_archive(
+                str(Path(temp_dir, "ravendb-server")),
+                "zip",
+                CopyServerFromNugetProvider().server_files,
+            )
             with EmbeddedServer() as embedded:
                 server_options = ServerOptions()
                 server_options = self.configure_server_options(temp_dir, server_options)
-                server_options.with_external_server("ravendb_embedded/target/ravendb-server.zip")
+                server_options.with_external_server(server_zip)
                 embedded.start_server(server_options)
 
                 database_options = DatabaseOptions.from_database_name("Test")
@@ -37,7 +45,7 @@ class TestCustomProvider(TestCase):
             with EmbeddedServer() as embedded:
                 server_options = ServerOptions()
                 server_options = self.configure_server_options(temp_directory, server_options)
-                server_options.with_external_server(CopyServerFromNugetProvider.SERVER_FILES)
+                server_options.with_external_server(CopyServerFromNugetProvider().server_files)
                 embedded.start_server(server_options)
 
                 database_options = DatabaseOptions.from_database_name("Test")

--- a/tests/test_runtime_framework_version_matcher.py
+++ b/tests/test_runtime_framework_version_matcher.py
@@ -9,28 +9,16 @@ from ravendb_embedded.runtime_framework_version_matcher import (
 
 class TestRuntimeFrameworkVersionMatcher(TestCase):
     def test_match_1(self):
-        options = ServerOptions()
-        default_framework_version = ServerOptions.INSTANCE().framework_version
+        # Default framework version is unenforced (empty); match() returns it unchanged.
+        self.assertFalse(ServerOptions.INSTANCE().framework_version)
 
-        self.assertIn(RuntimeFrameworkVersionMatcher.GREATER_OR_EQUAL, default_framework_version)
+        options = ServerOptions()
 
         options.framework_version = None
         self.assertIsNone(RuntimeFrameworkVersionMatcher.match(options))
 
-        options = ServerOptions()
-        framework_version = RuntimeFrameworkVersion(options.framework_version)
-        framework_version.patch = None
-
-        options.framework_version = framework_version.__str__()
-        match = RuntimeFrameworkVersionMatcher.match(options)
-        self.assertIsNotNone(match)
-
-        match_framework_version = RuntimeFrameworkVersion(match)
-        self.assertIsNotNone(match_framework_version.major)
-        self.assertIsNotNone(match_framework_version.minor)
-        self.assertIsNotNone(match_framework_version.patch)
-
-        self.assertTrue(framework_version.match(match_framework_version))
+        options.framework_version = ""
+        self.assertEqual("", RuntimeFrameworkVersionMatcher.match(options))
 
     def test_match_2(self):
         runtimes = self.get_runtimes()

--- a/tests/test_secured_basic.py
+++ b/tests/test_secured_basic.py
@@ -6,27 +6,22 @@ from unittest import TestCase
 from ravendb_embedded.embedded_server import EmbeddedServer
 from ravendb_embedded.options import ServerOptions, DatabaseOptions
 from ravendb_embedded.provide import CopyServerFromNugetProvider
-from tests import Person
+from tests import Person, pin_framework_version
+from tests.certificates import generate_self_signed_certificates
 
 
 class TestSecuredBasic(TestCase):
     def test_secured_embedded(self):
-        SERVER_CERTIFICATE_LOCATION = "C:\\RavenDB Clients\\Https\\server.pfx"
-        CA_CERTIFICATE_LOCATION = "C:\\RavenDB Clients\\Https\\ca.crt"
-        CLIENT_CERTIFICATE_LOCATION = "C:\\RavenDB Clients\\Https\\python.pem"
         temp_dir = tempfile.mkdtemp()
         try:
+            server_pfx, client_pem, ca_crt = generate_self_signed_certificates(temp_dir)
             with EmbeddedServer() as embedded:
                 server_options = ServerOptions()
-                server_options.secured(
-                    SERVER_CERTIFICATE_LOCATION,
-                    CLIENT_CERTIFICATE_LOCATION,
-                    ca_certificate_path=CA_CERTIFICATE_LOCATION,
-                )
-
+                server_options.secured(server_pfx, client_pem, ca_certificate_path=ca_crt)
                 server_options.data_directory = str(Path(temp_dir, "RavenDB"))
                 server_options.logs_path = str(Path(temp_dir, "Logs"))
                 server_options.provider = CopyServerFromNugetProvider()
+                pin_framework_version(server_options)
                 embedded.start_server(server_options)
 
                 database_options = DatabaseOptions.from_database_name("Test")


### PR DESCRIPTION
GitHub Actions workflow running the test suite + a `black` check on push / PR to `v7.2`.

### CI (`.github/workflows/tests.yml`) — 3 jobs
| OS | Python | .NET |
|----|--------|------|
| ubuntu | 3.13 | 10 (forced via fx-version) |
| ubuntu | 3.9 | 8 (default resolution) |
| windows | 3.13 | 10 (forced via fx-version) |

- **.NET 8 and .NET 10 both exercised.** The server targets net8.0, so default resolution covers .NET 8; runners preinstall 8, so .NET 10 is forced via `--fx-version` (env `RAVENDB_TEST_FRAMEWORK_VERSION` → `tests.pin_framework_version`). Verified RavenDB 7.2 runs on .NET 10.
- `pip install -e .` → `black --check .` (120 via `pyproject.toml`) → fetch bundled server (`setup.py sdist`) → `unittest discover`.

### Secured/HTTPS test
The secured test **generates its own self-signed certificate in-process** (via the `cryptography` dependency) with the extensions RavenDB requires (`digitalSignature`+`keyEncipherment`, `serverAuth`+`clientAuth` EKU, SAN `localhost`+`127.0.0.1`). So it **always runs** — every job including Windows — with no skip, no env vars, no hardcoded cert paths, and no openssl step in CI.

### Test fixes / cleanup
- Removed the hardcoded `C:\RavenDB Clients\...` developer paths (the secured test is now self-contained).
- `test_runtime_framework_version_matcher.test_match_1` — updated for the current empty/unenforced `framework_version` default (was stale).
- `test_custom_provider` — zip/directory external-server tests made cwd-independent and self-contained.

### Verified locally (Python 3.12, fresh venv)
Full suite green on **.NET 8** and **.NET 10**: `9 tests OK` each, with the secured test **running** (not skipped). No `RAVEN_LICENSE` needed (community edition).
